### PR TITLE
fix: semantic tag sort in get_all_tags

### DIFF
--- a/gtbump/__init__.py
+++ b/gtbump/__init__.py
@@ -52,7 +52,7 @@ def get_last_tag():
 
 def get_all_tags():
     """Get all annotated (closest) tags by lexicographic order."""
-    tags = run("git tag --sort=-refname").split("\n")
+    tags = run("git tag --sort -v:refname").split("\n")
 
     # Parse semver tag: v0.0.0-xxxx (optional suffix).
     out = []


### PR DESCRIPTION
**Issue**

`gtbump --changelog` prints the changelog for old versions once the minor tag crosses the number 9.

Changelog for `v5.9.0`

![ezgif com-gif-maker](https://user-images.githubusercontent.com/51631122/169044128-26ce8c5f-bef0-4e75-a8f7-420c9b38213a.png)

Even though the latest tag is `v5.14.1`.

<img width="974" alt="image" src="https://user-images.githubusercontent.com/51631122/169044396-804a024b-0b5a-40f4-b2da-0f832e9843da.png">

---

This happens since the get_all_tags functions uses the command `git tag --sort=-refname` which does lexical sort. See example below:

<img width="291" alt="image" src="https://user-images.githubusercontent.com/51631122/169040562-a03c814b-c6d6-440a-a6b6-59c3664e4405.png">

While v5.13.0 is greater than v5.9.0, it gets ranked incorrectly.

Using `git tag --sort -v:refname` (which sorts by version) fixes this. See: 

<img width="255" alt="image" src="https://user-images.githubusercontent.com/51631122/169040784-64ed1ae0-cf3a-49a2-bc80-dee9c639ffee.png">
